### PR TITLE
Fix profile redirect #133 

### DIFF
--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -2,7 +2,6 @@ from django.urls import path, include
 from django.contrib.auth import views as auth_views
 from django.urls import reverse_lazy
 from . import views
-
 urlpatterns = [
     path('logout/',auth_views.LogoutView.as_view(template_name='registration/logout.html'),name='logout'),
     path('password_change/done/',auth_views.PasswordChangeDoneView.as_view(template_name='registration/password_change_done_.html'),name='password_change_done'),
@@ -17,6 +16,7 @@ urlpatterns = [
       ) , name='password_reset_confirm_'),
     path('login/',auth_views.LoginView.as_view(template_name='registration/login.html'),name='login'),
     path('', include('django.contrib.auth.urls')),
+    path('profile_redirect', views.profile_redirect, name='profile_redirect'),
     path('login_redirect', views.login_redirect, name='login_redirect'),
     path('delete_me', views.delete_me, name='delete_me'),
     path('signup_student', views.student_signup, name='student_signup'),
@@ -26,3 +26,4 @@ urlpatterns = [
     path('approve_hospitals', views.approve_hospitals, name='approve_hospitals'),
     path('change_hospital_approval/<str:uuid>/', views.change_hospital_approval, name='change_hospital_approval')
 ]
+

--- a/backend/apps/accounts/utils.py
+++ b/backend/apps/accounts/utils.py
@@ -32,4 +32,4 @@ def send_password_set_email(email, host, subject_template, template='registratio
         )
         logger.debug("Sent!")
     else:
-        logger.warn("Email to " + str(emaiL) + " not sent because form is invalid")
+        logger.warn("Email to " + str(email) + " not sent because form is invalid")

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -115,6 +115,24 @@ def register_hospital_in_db(request, m):
 
 from django.contrib import messages
 
+
+@login_required
+def profile_redirect(request):
+    user = request.user
+
+    if user.is_student:
+        return HttpResponseRedirect('profile_student')
+
+    elif user.is_hospital:
+        return HttpResponseRedirect('profile_hospital')
+
+    elif user.is_staff:
+        return HttpResponseRedirect('approve_hospitals')
+
+    else:
+        #TODO: throw 404
+        HttpResponse('Something wrong in database')
+
 @login_required
 def login_redirect(request):
     user = request.user

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -76,12 +76,12 @@
                     </li>
                     {% if user.is_authenticated %}
                     <li class="nav-item {% if "profile" in request.path %}active{% endif %}">
-                        <a class="nav-link" href="/accounts/login_redirect">{% blocktrans %}Mein
+                        <a class="nav-link" href="/accounts/profile_redirect">{% blocktrans %}Mein
                             Profil{% endblocktrans %}</a>
                     </li>
                     {% else %}
                     <li class="nav-item {% if "login" in request.path %}active{% endif %}">
-                        <a class="nav-link" href="/accounts/login_redirect">{% blocktrans %}Login{% endblocktrans %}</a>
+                        <a class="nav-link" href="/accounts/profile_redirect">{% blocktrans %}Login{% endblocktrans %}</a>
                     </li>
                     {% endif %}
 


### PR DESCRIPTION
Issue: Profile page cannot be reached via the nav-bar

Added function similar to `login_redirect` called `profile_redirect` which is referenced in the navbar button. `profile_redirect` always points to the profile (edit) page, while `login_redirect` shows the page most users would need after a login (mapview for students). Maybe add mapview for institutions as well?