### PR TITLE
Added '.org' domain to allowed hosts

### DIFF
--- a/backend/match4healthcare/settings/production.py
+++ b/backend/match4healthcare/settings/production.py
@@ -11,8 +11,8 @@ DEBUG = False
 
 SECRET_KEY = os.environ['SECRET_KEY']
 
-ALLOWED_HOSTS = ['matchmedisvsvirus.dynalias.org', 'helping-health.from-de.com', 'match4healthcare.eu',
-                 'match4healthcare.org', 'medis-vs-covid19.de']
+ALLOWED_HOSTS = ['matchmedisvsvirus.dynalias.org', 'helping-health.from-de.com', 'match4healthcare.de',
+                 'match4healthcare.eu', 'match4healthcare.org', 'medis-vs-covid19.de']
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases

--- a/backend/match4healthcare/settings/production.py
+++ b/backend/match4healthcare/settings/production.py
@@ -12,7 +12,7 @@ DEBUG = False
 SECRET_KEY = os.environ['SECRET_KEY']
 
 ALLOWED_HOSTS = ['matchmedisvsvirus.dynalias.org', 'helping-health.from-de.com', 'match4healthcare.eu',
-                 'medis-vs-covid19.de']
+                 'match4healthcare.org', 'medis-vs-covid19.de']
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases


### PR DESCRIPTION
Add match4healthcare.org and match4healthcare.de as a valid domain for our server to access Django.