### PR TITLE
Add development specific checks

### DIFF
--- a/backend/apps/checks.py
+++ b/backend/apps/checks.py
@@ -51,7 +51,8 @@ def check_env_variables_set(app_configs=None, **kwargs):
             Error(
                 "Django secret key not found.",
                 hint=(
-                    "You have to set the django application secret key in you environment with 'export SECRET_KEY=<<yourKey>>'."),
+                    "You have to set the django application secret key in you environment with "
+                    "'export SECRET_KEY=<<yourKey>>'."),
                 id='env.E002',
             )
         )
@@ -61,9 +62,11 @@ def check_env_variables_set(app_configs=None, **kwargs):
                 "No Slack Webhook for logging set.",
                 hint=(
                     "Currently no logging to Slack Channels is configured.\n\t"
-                    "This is not necessary, but recommended for production deployment. A key can be generated using the documentation at:\n\t"
+                    "This is not necessary, but recommended for production deployment. A key can be generated "
+                    "using the documentation at:\n\t"
                     "https://slack.com/intl/en-at/help/articles/115005265063-Incoming-Webhooks-for-Slack\n\t"
-                    "To use Slack Error notifications set the webhook in your environment using 'export SLACK_LOG_WEBHOOK=<<webhook URL>>="),
+                    "To use Slack Error notifications set the webhook in your environment using "
+                    "'export SLACK_LOG_WEBHOOK=<<webhook URL>>="),
                 id='env.E003',
             )
         )        
@@ -78,20 +81,35 @@ def check_send_mails(app_configs=None, **kwargs):
 
     try:
         if settings.SENDGRID_API_KEY is None:
-            errors.append(
-                Error(
-                    "Sendgrid API key not found.",
-                    hint=(
-                        "You have to set the Sendgrid API key in you environment with 'export SENDGRID_API_KEY=<<yourKey>>'."),
-                    id='mails.E001',
+            if settings.DEBUG:
+                if settings.MAIL_RELAY_OPTION == 'sendgrid':
+
+                    errors.append(
+                        Error("Sendgrid API key found.",
+                                hint=("Your are in development mode, and want to use the sendgrid backend. "
+                                      "We did not find an API key.\n"
+                                      "You have to set the Sendgrid API key in you environment with 'export "
+                                      "SENDGRID_API_KEY=<<yourKey>>'.\n"
+                                      "If you want to use another backend set 'MAIL_RELAY_OPTION' in the development"
+                                      " settings to another value, e.g. 'file'.")))
+            else:
+                errors.append(
+                    Error(
+                        "Sendgrid API key not found.",
+                        hint=(
+                            "You have to set the Sendgrid API key in you environment with 'export "
+                            "SENDGRID_API_KEY=<<yourKey>>'."
+                            "If thats "),
+                        id='mails.E001',
+                    )
                 )
-            )
         else:
             if not does_sendgrid_sandbox_mail_work():
                 errors.append(
                     Error(
                         "You want to use Sendgrid, but sending a mail in sandbox mode fails.",
-                        hint=("Your API key might be invalid, something is up with sendgrid... go check it!"),
+                        hint=("Your API key might be invalid, something is up with sendgrid... "
+                              "go check it!"),
                         id='mails.E002',
                     )
                 )
@@ -103,7 +121,8 @@ def check_send_mails(app_configs=None, **kwargs):
                 "No SENDGRID API key.",
                 hint=(
                     "That's okay because you are using another email backend. "
-                    "If you do want to use the Sendgrid email backend, set the 'mail_relay_option' to sendgrid in 'development.py'"),
+                    "If you do want to use the Sendgrid email backend, set the "
+                    "'MAIL_RELAY_OPTION' to sendgrid in 'development.py'"),
                 id='env.E001',
             )
         )

--- a/backend/match4healthcare/settings/development.py
+++ b/backend/match4healthcare/settings/development.py
@@ -28,15 +28,15 @@ NOREPLY_MAIL = 'match4healthcare-DEVELOPMENT<noreply@example.de>'
 
 # Possible values are 'file', 'external', 'sendgrid'
 # For storing mails local in files files, sending external (uberspace) or sending over sendgrid (production like)
-mail_relay_option = 'sendgrid'
+MAIL_RELAY_OPTION = 'file'
 
 # +++ Store files locally
-if mail_relay_option == 'file':
+if MAIL_RELAY_OPTION == 'file':
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH = os.path.join(RUN_DIR, "sent_emails")
 
 # +++ Use local debug server
-elif mail_relay_option == 'external':
+elif MAIL_RELAY_OPTION == 'external':
     EMAIL_HOST = 'spahr.uberspace.de'
     EMAIL_PORT = 587
     EMAIL_HOST_USER = 'noreply@medisvs.spahr.uberspace.de'
@@ -44,7 +44,7 @@ elif mail_relay_option == 'external':
     EMAIL_USE_TLS = False
 
 # +++ Use sendgrid
-elif mail_relay_option == 'sendgrid':
+elif MAIL_RELAY_OPTION == 'sendgrid':
     # Use API instead of SMTP server
     use_sendgrid_api = True
 


### PR DESCRIPTION
- this prevents errors when using a mail backend that is not sendgrid
