### PR TITLE
Fix #482

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
     -   id: black
         args: [--line-length=100]
-        language_version: python3.6
+        language_version: python3
         exclude: |
                 (?x)(
                     ^backend/apps/[a-z]*/migrations/[0-9A-z]*.py|


### PR DESCRIPTION
Unfortunately this was introduced here: https://github.com/match4everyone/match4healthcare/pull/450#discussion_r419133458
In theory, this language version should not even be necessary. On my python 3.6 machine it also runs fine with this flag set to `python3.7`, it automatically gets downloaded to the pre-commit venv.