### PR TITLE
Remove hard coded mapbox token from hospital_map template

### DIFF
--- a/backend/apps/ineedstudent/templates/map_hospitals.html
+++ b/backend/apps/ineedstudent/templates/map_hospitals.html
@@ -125,7 +125,7 @@ $(window).on("resize", function () {
 <script type="text/javascript">
 
 	var mymap = L.map('mapid').setView([51.13, 10.018], 6);
-   L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1Ijoiam9zYXVkZXIiLCJhIjoiY2s4MWNxa2QzMDNkejNrcDVhbzV6MDMxYSJ9.O4sLC7VSSgy4S7EKjNoG1g', {
+   L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}@2x?access_token={{ mapbox_token }}', {
     attribution: ' <a href="https://www.mapbox.com/about/maps/">© Mapbox</a> | <a href="http://www.openstreetmap.org/copyright">© OpenStreetMap</a> | <a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
     maxZoom: 18,
     id: 'mapbox/streets-v11',

--- a/backend/apps/ineedstudent/views.py
+++ b/backend/apps/ineedstudent/views.py
@@ -43,6 +43,7 @@ def hospital_overview(request):
     template = loader.get_template("map_hospitals.html")
     context = {
         "locations": list(locations_and_number.values()),
+        "mapbox_token": settings.MAPBOX_TOKEN,
     }
     return HttpResponse(template.render(context, request))
 


### PR DESCRIPTION
I found another place were our token was hard-coded.
The URL to access this page is 'ineedstudent/hospital_map'
