### PR TITLE
Fix Issue 512 - Fractional Distances in Student Lookup

### DIFF
--- a/backend/apps/iamstudent/views.py
+++ b/backend/apps/iamstudent/views.py
@@ -223,7 +223,7 @@ def clean_request(request):
 @login_required
 @hospital_required
 def student_list_view(request, countrycode, plz, distance):
-    # remove parameters fro mthe get request that should not be taken into account
+    # remove parameters from the get request that should not be taken into account
     request_filtered = clean_request(request)
 
     # only show validated students
@@ -232,7 +232,8 @@ def student_list_view(request, countrycode, plz, distance):
     # filter by location
     countrycode = request.GET.get("countrycode", countrycode)
     plz = request.GET.get("plz", plz)
-    distance = int(request.GET.get("distance", distance))
+    if request.GET.get("distance"):
+        distance = float(request.GET.get("distance").replace(",", "."))
 
     if countrycode not in plzs or plz not in plzs[countrycode]:
         return HttpResponse(

--- a/backend/apps/ineedstudent/converters.py
+++ b/backend/apps/ineedstudent/converters.py
@@ -1,0 +1,18 @@
+class DecimalPointFloatConverter:
+    """
+    Custom Django converter for URLs. Parses floats with a decimal point (not with a comma!)
+    Allows for integers too, parses values in this or similar form:
+    - 100.0
+    - 100
+
+    Will NOT work for these forms:
+    - 100.000.000
+    - 100,0
+    """
+    regex = '[0-9]*[.]?[0-9]*'
+
+    def to_python(self, value):
+        return float(value)
+
+    def to_url(self, value):
+        return str(value)

--- a/backend/apps/ineedstudent/converters.py
+++ b/backend/apps/ineedstudent/converters.py
@@ -1,6 +1,8 @@
 class DecimalPointFloatConverter:
     """
-    Custom Django converter for URLs. Parses floats with a decimal point (not with a comma!)
+    Custom Django converter for URLs.
+
+    Parses floats with a decimal point (not with a comma!)
     Allows for integers too, parses values in this or similar form:
     - 100.0
     - 100
@@ -9,7 +11,8 @@ class DecimalPointFloatConverter:
     - 100.000.000
     - 100,0
     """
-    regex = '[0-9]*[.]?[0-9]*'
+
+    regex = "[0-9]*[.]?[0-9]*"
 
     def to_python(self, value):
         return float(value)

--- a/backend/apps/ineedstudent/urls.py
+++ b/backend/apps/ineedstudent/urls.py
@@ -4,7 +4,7 @@ from apps.iamstudent.views import student_list_view
 
 from . import converters, views
 
-register_converter(converters.DecimalPointFloatConverter, 'float')
+register_converter(converters.DecimalPointFloatConverter, "float")
 
 
 urlpatterns = [

--- a/backend/apps/ineedstudent/urls.py
+++ b/backend/apps/ineedstudent/urls.py
@@ -1,11 +1,14 @@
-from django.urls import path
+from django.urls import path, register_converter
 
 from apps.iamstudent.views import student_list_view
 
-from . import views
+from . import converters, views
+
+register_converter(converters.DecimalPointFloatConverter, 'float')
+
 
 urlpatterns = [
-    path("students/<countrycode>/<plz>/<int:distance>", student_list_view, name="list_by_plz",),
+    path("students/<countrycode>/<plz>/<float:distance>", student_list_view, name="list_by_plz",),
     # path('students_testing/<countrycode>/<plz>/<int:distance>', views.student_list_view, name='student_list_view'),
     path("hospitals/<countrycode>/<plz>", views.hospital_list, name="hospital_list"),
     path("hospital_map", views.hospital_overview, name="hopsital_map"),


### PR DESCRIPTION
Fixes issue #512 were inputting a fractional distance in the hospital lookup (to find students) would fail.
- Added support for float numbers in the URL when requesting the page
- Parse floating point numbers from GET requests