### PR TITLE
520 fix createfakeusers attributes

### DIFF
--- a/backend/apps/iamstudent/management/commands/createfakeusers.py
+++ b/backend/apps/iamstudent/management/commands/createfakeusers.py
@@ -117,6 +117,7 @@ class Command(BaseCommand):
                 availability_start="{}-{:02d}-{:02d}".format(year, months[i], days[i]),
                 zeitliche_verfuegbarkeit=np.random.choice([1, 2, 3, 4]),
                 umkreis=np.random.choice([1, 2, 3, 4], p=[0.2, 0.5, 0.27, 0.03]),
+                unterkunft_gewuenscht=np.random.choice([True, False], p=[0.1, 0.9]),
                 **kwd
             )
 

--- a/backend/apps/iamstudent/management/commands/createfakeusers.py
+++ b/backend/apps/iamstudent/management/commands/createfakeusers.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
             Student.objects.create(
                 user=u,
                 plz=plzs[i],
-                braucht_bezahlung=np.random.choice([0, 1]),
+                braucht_bezahlung=np.random.choice([1, 2, 3]),
                 is_activated=np.random.choice([True, False], p=[0.95, 0.05]),
                 einwilligung_agb=True,
                 datenschutz_zugestimmt=True,

--- a/backend/apps/iamstudent/management/commands/createfakeusers.py
+++ b/backend/apps/iamstudent/management/commands/createfakeusers.py
@@ -115,6 +115,8 @@ class Command(BaseCommand):
                 datenschutz_zugestimmt=True,
                 einwilligung_datenweitergabe=True,
                 availability_start="{}-{:02d}-{:02d}".format(year, months[i], days[i]),
+                zeitliche_verfuegbarkeit=np.random.choice([1, 2, 3, 4]),
+                umkreis=np.random.choice([1, 2, 3, 4], p=[0.2, 0.5, 0.27, 0.03]),
                 **kwd
             )
 


### PR DESCRIPTION
Fixes issue #520 where createfakeusers would generate invalid users.

Removed the option "0" / "egal" as it cannot be selected by the users and will throw an error while filtering for students [because it does not has an assigned text which is needed to display the icons in the table]

Also added two more fields "umkreis" and "zeitliche_verfuegbarkeit" as they are in theory required by the form (did not throw any errors yet).