### PR TITLE
Remove (possible) syntax error in backup.sh

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-source database.prod.env
 docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml exec backend sh -c 'python3 manage.py dumpdata > /match4healthcare-backend/backups/fixture-$(date +%F_%H%M%S).json'
-docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml exec database sh -c "pg_dumpall -U $POSTGRES_USER> /backups/pg_backup-$(date +%F_%H%M%S).sql"
+docker-compose -f docker-compose.dev.yml -f docker-compose.prod.yml exec database sh -c 'pg_dumpall -U $POSTGRES_USER> /backups/pg_backup-$(date +%F_%H%M%S).sql'


### PR DESCRIPTION
**Topic:**
backup.sh sources a docker .env file. Docker .env files don't use quotes (instead quotes are included as part of the variable). Depending on the contents of docker.env file this can cause syntax errors and unexpected behaviour.

**Relevant issues:**
none

**Further description:**
The script sourced env files because double quotes were used and the parameters to the database backup command were expanded in the host bash instead of inside the docker container.

After switching to single quotes it is no longer necessary to source the env file. As this was error prone anyway (and causes an error message with certain parameter values) it was removed.

**Alternative approaches that could be considered:**
Write some logic to parse the source file, as the variables are only needed to execute a command inside the container where the vars are already present this is not necessary